### PR TITLE
[DEV1A-6041] - Code Merge for VS Code Extension Pack – 2025.1.0 Release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "oneapi-extension-pack",
-    "version": "0.0.5",
+    "version": "0.0.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "oneapi-extension-pack",
-            "version": "0.0.5",
+            "version": "0.0.7",
             "license": "MIT",
             "engines": {
                 "vscode": "^1.81.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "publisher": "intel-corporation",
     "license": "MIT",
     "icon": "media/oneapi-logo.png",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "keywords": [
         "intel",
         "oneapi",
@@ -23,7 +23,6 @@
     ],
     "extensionPack": [
         "intel-corporation.oneapi-environment-configurator",
-        "intel-corporation.vscode-oneapi-devcloud-connector",
         "intel-corporation.oneapi-gdb-debug",
         "intel-corporation.oneapi-analysis-configurator",
         "intel-corporation.oneapi-samples"


### PR DESCRIPTION
**JIRA**: https://jira.devtools.intel.com/browse/DEV1A-6041
**Build Result**: Attached the VSIX file as the build is not enabled in GitHub Actions. Built it locally.
**Download Link**: [oneapi-extension-pack-0.0.7.vsix.zip](https://github.com/user-attachments/files/19361863/oneapi-extension-pack-0.0.7.vsix.zip)
